### PR TITLE
Octokit Github Version Check

### DIFF
--- a/FabricHealer/FabricHealerManager.cs
+++ b/FabricHealer/FabricHealerManager.cs
@@ -273,12 +273,16 @@ namespace FabricHealer
                             }
                         }
 
-                        // Check for new version once a day.
-                        if (DateTime.UtcNow.Subtract(LastVersionCheckDateTime) >= OperationalTelemetryRunInterval)
+                        if (ConfigSettings.CheckGithubVersion)
                         {
-                            await CheckGithubForNewVersionAsync();
-                            LastVersionCheckDateTime = DateTime.UtcNow;
+                            // Check for new version once a day.
+                            if (DateTime.UtcNow.Subtract(LastVersionCheckDateTime) >= OperationalTelemetryRunInterval)
+                            {
+                                await CheckGithubForNewVersionAsync();
+                                LastVersionCheckDateTime = DateTime.UtcNow;
+                            }
                         }
+
 
                         await Task.Delay(
                             TimeSpan.FromSeconds(

--- a/FabricHealer/PackageRoot/Config/Settings.xml
+++ b/FabricHealer/PackageRoot/Config/Settings.xml
@@ -7,6 +7,7 @@
 		<Parameter Name="EnableVerboseLogging" Value="" MustOverride="true" />
 		<Parameter Name="EnableTelemetry" Value="" MustOverride="true" />
 		<Parameter Name="EnableETW" Value="" MustOverride="true" />
+        <Parameter Name="CheckGithubVersion" Value="" MustOverride="true"/>
 		<!-- Big Red Button: You can turn FabricHealer on and off with a versionless parameter-only application upgrade. -->
 		<Parameter Name="EnableAutoMitigation" Value="" MustOverride="true" />
 		<Parameter Name="EnableOperationalTelemetry" Value="" MustOverride="true" />

--- a/FabricHealer/Repair/RepairConstants.cs
+++ b/FabricHealer/Repair/RepairConstants.cs
@@ -154,5 +154,8 @@ namespace FabricHealer.Repair
         public const string MaxOutstandingRepairs = "MaxOutstandingRepairs";
         public const string NodeProbationPeriod = "NodeProbationPeriod";
         public const string MinHealthStateDuration = "MinHealthStateDuration";
+
+        // Octokit Github Version Check
+        public const string CheckGithubVersion = "CheckGithubVersion";
     }
 }

--- a/FabricHealer/Utilities/ConfigSettings.cs
+++ b/FabricHealer/Utilities/ConfigSettings.cs
@@ -63,6 +63,12 @@ namespace FabricHealer.Utilities
             private set;
         }
 
+        public bool CheckGithubVersion
+        {
+            get;
+            private set;
+        }
+
         // For Azure LogAnalytics Telemetry
         public string LogAnalyticsWorkspaceId
         {
@@ -186,6 +192,11 @@ namespace FabricHealer.Utilities
             if (bool.TryParse(GetConfigSettingValue(RepairConstants.RepairManagerConfigurationSectionName, RepairConstants.EnableCustomRepairPredicateType), out bool enableCustomRepairPredicateType))
             {
                 EnableCustomRepairPredicateType = enableCustomRepairPredicateType;
+            }
+
+            if(bool.TryParse(GetConfigSettingValue(RepairConstants.RepairManagerConfigurationSectionName, RepairConstants.CheckGithubVersion), out bool checkGithubVersion))
+            {
+                CheckGithubVersion = checkGithubVersion;
             }
 
             // Logger

--- a/FabricHealerApp/ApplicationPackageRoot/ApplicationManifest.xml
+++ b/FabricHealerApp/ApplicationPackageRoot/ApplicationManifest.xml
@@ -61,6 +61,7 @@
             <Parameter Name="EnableLogicRuleTracing" Value="[EnableLogicRuleTracing]" />
             <Parameter Name="EnableCustomServiceInitializers" Value="[EnableCustomServiceInitializers]" />
             <Parameter Name="EnableCustomRepairPredicateType" Value="[EnableCustomRepairPredicateType]" />
+            <Parameter Name="CheckGithubVersion" Value="[CheckGithubVersion]" />
           </Section>
           <!-- Repair policies -->
           <Section Name="AppRepairPolicy">

--- a/FabricHealerApp/ApplicationPackageRoot/ApplicationManifest.xml
+++ b/FabricHealerApp/ApplicationPackageRoot/ApplicationManifest.xml
@@ -5,6 +5,7 @@
     <Parameter Name="AutoMitigationEnabled" DefaultValue="true" />
     <Parameter Name="EnableETW" DefaultValue="false" />
     <Parameter Name="HealthCheckIntervalInSeconds" DefaultValue="30" />
+    <Parameter Name="CheckGithubVersion" DefaultValue="true"/>
     <!-- If set to true, then FH will emit log events containing the full text of the logic rule with the currently executing external repair predicate.
          This is extremely useful for both debugging and auditing repair rules. -->
     <Parameter Name="EnableLogicRuleTracing" DefaultValue="true" />


### PR DESCRIPTION
Octokit/Github Version Check cannot be used in airgapped clusters. So making the Github Version Check a configurable setting 